### PR TITLE
refactor- Unify All Firefly Services navigation in config

### DIFF
--- a/src/pages/config.md
+++ b/src/pages/config.md
@@ -11,6 +11,7 @@
         - [InDesign API](https://developer.adobe.com/firefly-services/docs/indesign-apis/?aio_internal) Docs and references for InDesign API.
         - [Substance 3D API](https://developer.adobe.com/firefly-services/docs/s3dapi/?aio_internal) Unlock generative AI for rendering and object composites.
         - [Illustrator API](https://developer.adobe.com/firefly-services/docs/illustrator/?aio_internal) Docs and references for Illustrator API.
+        - [Creative Production API](https://developer.adobe.com/firefly-services/docs/workflow-builder-api/?aio_internal) Docs and references for Firefly Creative Production API.
         - [Content Tagging API](https://experienceleague.adobe.com/docs/experience-platform/intelligent-services/content-commerce-ai/overview.html) Docs and references for Content Tagging services.
     - [About InDesign API](/index.md)
     - [Getting Started](/getting-started/index.md)


### PR DESCRIPTION
# Summary
Unifies the `All Firefly Services` section in `src/pages/config.md` with the same eleven service links and descriptions as the other live Firefly Services API documentation repos, including the Creative Production API entry (URL unchanged). Lightroom and Audio/Video configs no longer use the extra dash before descriptions. Substance 3D API docs include the Illustrator API row that was previously missing.

# Changes

## `src/pages/config.md`
* Replaces the `All Firefly Services` block with the canonical shared navigation list.

# Context

## Jira
No ticket

Made with [Cursor](https://cursor.com)