### PR TITLE
docs/FFENT-10577- Align All Firefly Services global nav with Express

### DIFF
--- a/src/pages/config.md
+++ b/src/pages/config.md
@@ -12,6 +12,7 @@
         - [Substance 3D API](https://developer.adobe.com/firefly-services/docs/s3dapi/?aio_internal) Unlock generative AI for rendering and object composites.
         - [Illustrator API](https://developer.adobe.com/firefly-services/docs/illustrator/?aio_internal) Docs and references for Illustrator API.
         - [Creative Production API](https://developer.adobe.com/firefly-services/docs/workflow-builder-api/?aio_internal) Docs and references for Firefly Creative Production API.
+        - [Express API](https://developer.adobe.com/firefly-services/docs/express-api/?aio_internal) Docs and references for Express API.
         - [Content Tagging API](https://experienceleague.adobe.com/docs/experience-platform/intelligent-services/content-commerce-ai/overview.html) Docs and references for Content Tagging services.
     - [About InDesign API](/index.md)
     - [Getting Started](/getting-started/index.md)


### PR DESCRIPTION
# Summary
Adds the Express API entry to the **All Firefly Services** global navigation dropdown in `config.md` so it matches other live Firefly Services API microsites.

# Changes

## `src/pages/config.md`
* Adds the Express API link (with description) after Creative Production API and before Content Tagging API in the All Firefly Services dropdown.

# Context

## Jira
[FFENT-10577](https://jira.corp.adobe.com/browse/FFENT-10577)
